### PR TITLE
Install and Clean in one step

### DIFF
--- a/docker/Dockerfile_dev-base
+++ b/docker/Dockerfile_dev-base
@@ -25,15 +25,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-serial \
     python-is-python3 \
     libpython3-stdlib \
-    libtool-bin
-
-RUN python -m pip install -U future lxml pexpect flake8
-
-# Cleanup
-RUN apt-get clean \
-	&& apt-get -y autoremove \
-	&& apt-get clean autoclean \
+    libtool-bin \
+    && apt-get clean \
+    && apt-get -y autoremove \
+    && apt-get clean autoclean \
     && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    
+RUN python -m pip install -U future lxml pexpect flake8
 
 # Set ccache to the PATH
 ENV PATH="/usr/lib/ccache:$PATH"


### PR DESCRIPTION
this is to prevent the apt-get install "layer" keeping the installed packages, as each RUN step is a docker layer

there is ~100mb of packages this change will remove

currently its
	546.3 MB	
RUN RUN apt-get update && apt-get install --no-install-recommends -y lsb-release sudo wget software-properties-common build-essential ccache g++ gdb gawk git make cmake ninja-build libtool libxml2-dev libxslt1-dev python3-pip python3-setuptools python3-numpy python3-pyparsing python3-serial python-is-python3 libpython3-stdlib libtool-bin # buildkit