### PR TITLE
ROS2 Jazzy: Create new Dockerfile for jazzy container

### DIFF
--- a/docker/Dockerfile_dev-ros
+++ b/docker/Dockerfile_dev-ros
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM ros:humble-ros-base AS main-setup
+ARG ROS_DISTRO=humble
+FROM ros:${ROS_DISTRO}-ros-base AS main-setup
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -31,7 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     default-jre \
     socat \
     ros-dev-tools \
-    ros-humble-launch-pytest \
+    ros-${ROS_DISTRO}-launch-pytest \
     && apt-get clean \
     && apt-get -y autoremove \
     && apt-get autoclean \
@@ -55,6 +56,7 @@ RUN set -eux; \
 		--disable-pip-version-check \
 		--no-cache-dir \
 		--no-compile \
+        --break-system-packages \
 		"pip==$PYTHON_PIP_VERSION" \
 		"setuptools==$PYTHON_SETUPTOOLS_VERSION" \
 	; \
@@ -62,7 +64,7 @@ RUN set -eux; \
 	\
 	pip --version
 
-RUN python -m pip install --no-cache-dir -U wheel future lxml pexpect flake8 empy==3.3.4 pyelftools tabulate pymavlink pre-commit junitparser
+RUN python -m pip install --no-cache-dir --break-system-packages -U wheel future lxml pexpect flake8 empy==3.3.4 pyelftools tabulate pymavlink pre-commit junitparser
 
 RUN mkdir -p /__w/ardupilot/ardupilot && git config --global --add safe.directory /__w/ardupilot/ardupilot && git config --system --add safe.directory /__w/ardupilot/ardupilot
 

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -25,6 +25,8 @@ echo "BUILDING COVERAGE"
 docker build -t ardupilot/ardupilot-dev-coverage:latest -f Dockerfile_dev-coverage .
 echo "BUILDING PERIPH"
 docker build -t ardupilot/ardupilot-dev-periph:latest -f Dockerfile_dev-periph .
-echo "BUILDING ROS2"
-docker build -t ardupilot/ardupilot-dev-ros:latest -f Dockerfile_dev-ros .
+echo "BUILDING ROS2 HUMBLE"
+docker build --build-arg ROS_DISTRO=humble -t ardupilot/ardupilot-dev-ros:humble -f Dockerfile_dev-ros .
+echo "BUILDING ROS2 JAZZY"
+docker build --build-arg ROS_DISTRO=jazzy -t ardupilot/ardupilot-dev-ros:jazzy -f Dockerfile_dev-ros .
 popd


### PR DESCRIPTION
I changed `Dockerfile_dev-ros` to `Dockerfile_dev-ros-humble` and added a new file called  `Dockerfile_dev-ros-jazzy` . This is for the CI/CD pipeline so that it can test jumble and jazzy in different containers.