### PR TITLE
Fix ros2 apt sources

### DIFF
--- a/docker/Dockerfile_dev-ros
+++ b/docker/Dockerfile_dev-ros
@@ -3,6 +3,16 @@ ARG ROS_DISTRO=humble
 FROM ros:${ROS_DISTRO}-ros-base AS main-setup
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+RUN rm /etc/apt/sources.list.d/ros2-latest.list && rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+
+# Install curl and add latest ros-apt-source
+RUN apt-get update && apt-get install -y curl \
+    && export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') \
+    && curl -L -o /ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get install -y /ros2-apt-source.deb \
+    && rm /ros2-apt-source.deb
+
 RUN apt-get update && apt-get install --no-install-recommends -y \
     lsb-release \
     sudo \


### PR DESCRIPTION
The old ROS apt keys expired causing the build to fail. They need to be removed and the new ones installed through the latest `ros2-apt-source.deb` package.